### PR TITLE
add create db user and privs in cPanel to site-build.sh (readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ln -s ~/my-fw-project/docroot/* ~/public_html/
 ~/vendor/drush/drush/drush site:install illinois_framework --yes --db-url=$DB_URL --site-name=IllinoisFramework
 ```
 _site-build.sh_ using MySQL as your database
-> Requires you to add a new database and database user in your cPanel instance first. See https://answers.illinois.edu/illinois/84998
+> Optionally creates a new database and database user for you in your cPanel instance. If you have precreated your database, answer n to "Create Database?" 
 ```bash
 #!/bin/bash
 
@@ -44,14 +44,26 @@ COMPOSER_MEMORY_LIMIT=-1 composer create-project --remove-vcs --repository="{\"u
 ln -s ~/my-fw-project/vendor ~/vendor
 ln -s ~/my-fw-project/docroot/.* ~/public_html/
 ln -s ~/my-fw-project/docroot/* ~/public_html/
+CREATE="Y"
 
 read -p "Enter your MySQL database name ex: [CPANELUSER_XXX]:" DBNAME;
 read -p "Enter your database username ex: [CPANELUSER_XXX]:" DBUSER;
 read -p "Enter your database password:" DBPASSWORD;
+read -p "Create Database? [Y/n]" CREATE;
 
+if [ $CREATE != n ]; then
+#create database
+uapi Mysql create_database name=$DBNAME
+
+#create db user
+uapi  Mysql create_user name=$DBUSER password=$DBPASSWORD
+
+#add db user privs
+uapi Mysql set_privileges_on_database user=$DBUSER database=$DBNAME privileges=SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,INDEX,ALTER,CREATE%20TEMPORARY%20TABLES
+
+fi
 # Install Drupal
 ~/vendor/drush/drush/drush site:install --yes --site-name=IllinoisFramework --db-url="mysql://$DBUSER:$DBPASSWORD@localhost/$DBNAME"
-
 ```
 
 _site-remove.sh_


### PR DESCRIPTION
- Uses the cPanel API to create the database and database user
- Uses the cPanel API to set privileges for the database user

### Open Questions
- Currently still requests db name and db user containing the CPANELACCTNAME_ . We can just get that from the environment of the logged in user, but I was struggling a bit with how to tell the user they didn't need to include it, so I left that part of the instructions as-is.
- The language around whether to create the database or not is a bit awkward, and the process is not fully tested. Should we even keep this feature, or just assume the database does not exist?
- site-remove.sh does not currently remove the mysql database. Do we want to add that as well?